### PR TITLE
Fix cache interceptor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,4 @@ CACHE_TTL= "" # milliseconds
 # SECURITY
 HASH_SALT=""
 JWT_SECRET=""
+JWT_EXPIRES_IN=""

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,12 @@ jobs:
               env: 
                 HASH_SALT: ${{ secrets.HASH_SALT }}
                 JWT_SECRET: ${{ secrets.JWT_SECRET }}
+                JWT_EXPIRES_IN: 60s
               run: |
                 cp .env.example .env.test
                 sed -i "s/^HASH_SALT=.*/HASH_SALT=${HASH_SALT}/" .env.test
                 sed -i "s/^JWT_SECRET=.*/JWT_SECRET=${JWT_SECRET}/" .env.test
+                sed -i "s/^JWT_EXPIRES_IN=.*/JWT_EXPIRES_IN=${JWT_EXPIRES_IN}/" .env.test
                 cat .env.test
 
             - name: Install dependencies

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -15,7 +15,7 @@ import { AuthGuard } from './auth.guard';
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({
         secret: configService.get<string>('JWT_SECRET'),
-        signOptions: { expiresIn: '60s' }
+        signOptions: { expiresIn: configService.get<string>('JWT_EXPIRES_IN') }
       }),
       global: true,
       inject: [ConfigService]

--- a/src/resources/interceptors/http-cache.interceptor.ts
+++ b/src/resources/interceptors/http-cache.interceptor.ts
@@ -11,8 +11,9 @@ export class HttpCacheInterceptor extends CacheInterceptor {
       return undefined;
     }
 
-    const { url } = context.getArgs()[0];
-    const [_, endpoint, id] = url.split('/')
-    return `${endpoint}-${id}`;
+    const url = request.originalUrl || request.url;
+    const [_, endpoint, id] = url.split('/');
+
+    return id ? `${endpoint}-${id}` : endpoint;
   }
 }

--- a/src/resources/interceptors/http-cache.interceptor.ts
+++ b/src/resources/interceptors/http-cache.interceptor.ts
@@ -1,9 +1,16 @@
 import { CacheInterceptor } from "@nestjs/cache-manager";
-import { ExecutionContext, Injectable } from "@nestjs/common";
+import { ExecutionContext, HttpServer, Injectable } from "@nestjs/common";
 
 @Injectable()
 export class HttpCacheInterceptor extends CacheInterceptor {
   trackBy(context: ExecutionContext): string | undefined {
+    const request = context.switchToHttp().getRequest()
+    const isGetRequest = request.method === 'GET';
+
+    if (!isGetRequest) {
+      return undefined;
+    }
+
     const { url } = context.getArgs()[0];
     const [_, endpoint, id] = url.split('/')
     return `${endpoint}-${id}`;


### PR DESCRIPTION
- Adjusts the cache interceptor to function exclusively with GET requests. 
- Refactors code to use the property `url` correctly since libraries can change this property.
- Fix the object returned by the Cache Interceptor, avoiding `undefined` value when an `id` does not exist.

Close #48.