### PR TITLE
Make GET users endpoint private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jornada-milhas",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "A RESTful API for a travel platform, enabling destination registration, user testimonials, and user account management.",
   "private": true,
   "license": "MIT",

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -15,7 +15,7 @@ import { User } from './entities/user.entity';
 import { HashingPassword } from '../../resources/pipes/hashing-password.pipe';
 import { ListUserDto } from './dto/list-user.dto';
 import { Public } from '../../resources/decorators/public-route.decorator';
-import { ApiBadRequestResponse, ApiBearerAuth, ApiBody, ApiCreatedResponse, ApiForbiddenResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiSecurity, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOkResponse, ApiParam } from '@nestjs/swagger';
 
 @Controller('users')
 export class UsersController {
@@ -50,7 +50,6 @@ export class UsersController {
    * 
    * @throws {404} Any destination was found.
    */
-  @Public() // TODO: Tornar privada
   @Get()
   async findAll(): Promise<User[]> {
     const user = await this.usersService.findAll();

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -132,7 +132,10 @@ describe('UsersController (e2e)', () => {
 
   describe('/GET users', () => {
     it('should return status of 200', () => {
-      return request(app.getHttpServer()).get(USER_URL).expect(200);
+      return request(app.getHttpServer())
+        .get(USER_URL)
+        .auth(accessToken, { type: 'bearer' })
+        .expect(200);
     });
   });
 


### PR DESCRIPTION
Resolves #79 by removing the `@Public` decorator in the findAll method in the users controller.