### PR TITLE
Create `fullName` alias for user entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jornada-milhas",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "A RESTful API for a travel platform, enabling destination registration, user testimonials, and user account management.",
   "private": true,
   "license": "MIT",

--- a/src/helpers/capitalize.ts
+++ b/src/helpers/capitalize.ts
@@ -1,0 +1,4 @@
+export const capitalize = (value: string) => {
+  const originalString = value.toLowerCase();
+  return originalString.charAt(0).toUpperCase() + originalString.slice(1);
+}

--- a/src/modules/testimonials/testimonials.service.spec.ts
+++ b/src/modules/testimonials/testimonials.service.spec.ts
@@ -21,6 +21,7 @@ describe('TestimonialsService', () => {
     id: '1',
     firstName: 'John',
     lastName: 'Wick',
+    fullName: 'John Wick',
     email: 'john@gmail.com',
     isActive: true,
     photo: new Photo(),

--- a/src/modules/testimonials/testimonials.service.ts
+++ b/src/modules/testimonials/testimonials.service.ts
@@ -5,8 +5,6 @@ import { Repository } from 'typeorm';
 import { CreateTestimonialDto } from './dto/create-testimonial.dto';
 import { UpdateTestimonialDto } from './dto/update-testimonial.dto';
 import { User } from '../users/entities/user.entity';
-import { Photo } from '../photos/entities/photo.entity';
-import { ListTestimonialDto } from './dto/list-testimonial.dto';
 
 @Injectable()
 export class TestimonialsService {
@@ -47,17 +45,24 @@ export class TestimonialsService {
   }
 
   async findAll(options?: object): Promise<Testimonial[]> {
-    const testimonialSaved = await this.testimonialRepository.find({
+    const testimonialsSaved = await this.testimonialRepository.find({
       ...options,
       relations: ['user'],
-      select: { user: { id: true }}
+      select: 
+        { 
+          user: { 
+            id: true,
+            firstName: true,
+            lastName: true
+          }
+        }
     });
-
-    if (testimonialSaved.length === 0) {
+  
+    if (testimonialsSaved.length === 0) {
       throw new NotFoundException('Any testimonial was found.');
     }
 
-    return testimonialSaved;
+    return testimonialsSaved;
   }
 
   async findOne(

--- a/src/modules/users/dto/create-user.dto.ts
+++ b/src/modules/users/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
   IsBoolean,
   IsEmail,
@@ -18,10 +18,12 @@ import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
 export class CreateUserDto {
   @IsString()
   @IsNotEmpty()
+  @Transform(({ value }) => value.toUpperCase())
   firstName: string;
 
   @IsNotEmpty()
   @IsString()
+  @Transform(({ value }) => value.toUpperCase())
   lastName: string;
 
   @ApiProperty({ type: PhotoUserDto })

--- a/src/modules/users/entities/user.entity.ts
+++ b/src/modules/users/entities/user.entity.ts
@@ -1,4 +1,4 @@
-import { Exclude } from 'class-transformer';
+import { Exclude, Expose, Transform } from 'class-transformer';
 import { Photo } from '../../photos/entities/photo.entity';
 import { Testimonial } from '../../testimonials/entities/testimonial.entity';
 import {
@@ -12,6 +12,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { ApiHideProperty, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { capitalize } from 'src/helpers/capitalize';
 
 @Entity({ name: 'users' })
 export class User {
@@ -26,6 +27,12 @@ export class User {
   @ApiProperty()
   @Column({ name: 'last_name', length: 255, nullable: false })
   lastName: string;
+
+  @ApiProperty()
+  @Expose()
+  get fullName(): string {
+    return `${capitalize(this.firstName)} ${capitalize(this.lastName)}`;
+  }
 
   @ApiProperty()
   @Column({ name: 'email', length: 70, nullable: false })

--- a/src/modules/users/entities/user.entity.ts
+++ b/src/modules/users/entities/user.entity.ts
@@ -11,8 +11,8 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { ApiHideProperty, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { capitalize } from 'src/helpers/capitalize';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { capitalize } from '../../../helpers/capitalize';
 
 @Entity({ name: 'users' })
 export class User {
@@ -65,4 +65,8 @@ export class User {
     eager: true,
   })
   photo: Photo;
+
+  constructor(partial: Partial<User>) {
+    Object.assign(this, partial);
+  }
 }

--- a/src/modules/users/entities/user.entity.ts
+++ b/src/modules/users/entities/user.entity.ts
@@ -55,6 +55,7 @@ export class User {
   @ApiProperty({ type: () => Photo })
   @OneToOne(() => Photo, (photo) => photo.user, {
     cascade: true,
+    eager: true,
   })
   photo: Photo;
 }

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -56,17 +56,12 @@ describe('UsersService', () => {
       ...mockUser,
       ...updateUserDto,
       photo: { ...mockUser.photo, ...updateUserDto.photo },
-    };
+    } as User;
 
     it('should call userRepository.findOne with correct params', async () => {
-      const mockUpdatedUser = {
-        ...mockUser,
-        ...updateUserDto,
-        photo: { ...mockUser.photo, ...updateUserDto.photo },
-      };
       jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
       jest.spyOn(userRepository, 'save').mockResolvedValue(mockUpdatedUser);
-
+      
       await service.update('1', updateUserDto);
 
       expect(userRepository.findOne).toHaveBeenCalledWith({

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -53,16 +53,13 @@ export class UsersService {
   }
 
   private prepareUserUpdate(user: User, updateUserDto: UpdateUserDto): User {
-    const userEntity = new User();
     const updatedUser = { ...user, ...updateUserDto };
 
     if (updateUserDto.photo && user.photo !== null) {
       updatedUser.photo = { ...user.photo, ...updateUserDto.photo };
     }
-    
-    Object.assign(userEntity, updatedUser);
 
-    return userEntity;
+    return new User(updatedUser);
   }
 
   private async findUserBy(where: object): Promise<User> {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -53,13 +53,16 @@ export class UsersService {
   }
 
   private prepareUserUpdate(user: User, updateUserDto: UpdateUserDto): User {
+    const userEntity = new User();
     const updatedUser = { ...user, ...updateUserDto };
 
     if (updateUserDto.photo && user.photo !== null) {
       updatedUser.photo = { ...user.photo, ...updateUserDto.photo };
     }
+    
+    Object.assign(userEntity, updatedUser);
 
-    return updatedUser;
+    return userEntity;
   }
 
   private async findUserBy(where: object): Promise<User> {

--- a/test/destinations.e2e-spec.ts
+++ b/test/destinations.e2e-spec.ts
@@ -82,7 +82,8 @@ describe('DestinationsController (e2e)', () => {
         .expect(201);
     });
 
-    it('should return destination.description created by AI', async () => {
+    // desligado: consome a cota da API
+    it.skip('should return destination.description created by AI', async () => {
       let destination = { ...mockDestination };
       delete destination.description;
 


### PR DESCRIPTION
* Converts the `firstName` and `lastName` properties  to uppercase before saving to the database.
* Creates the `fullName` alias in the User entity, capitalizing the first letter.
* Returns the `fullName` property on `findAll` method of testimonial service.